### PR TITLE
fix: scrollable dashboard + wire real-mode label + export env var

### DIFF
--- a/packages/studio-ui/src/components/ChatLauncher.tsx
+++ b/packages/studio-ui/src/components/ChatLauncher.tsx
@@ -86,6 +86,9 @@ const ChatLauncher = () => {
       })
       if (!result.ok && result.error) setError(result.error)
       if (result.ok) setPrompt('')
+      // Update the mock-mode flag based on what the orchestrator actually did.
+      if (result.mode === 'real') useStudioStore.getState().setMockMode(false)
+      else useStudioStore.getState().setMockMode(true)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       setError(msg)
@@ -106,8 +109,10 @@ const ChatLauncher = () => {
     <section className="panel">
       <header className="panel-header">
         <h2 className="panel-title">Launch Swarm</h2>
-        <span className="font-mono text-[11px] uppercase tracking-wider text-slate-500">
-          {mockMode ? 'mock mode' : 'live'}
+        <span
+          className={`font-mono text-[11px] uppercase tracking-wider ${mockMode ? 'text-slate-500' : 'text-accent'}`}
+        >
+          {mockMode ? 'mock mode' : '● ruflo live'}
         </span>
       </header>
 

--- a/packages/studio-ui/src/hooks/useStudioTransport.ts
+++ b/packages/studio-ui/src/hooks/useStudioTransport.ts
@@ -59,6 +59,23 @@ const useElectronTransport = (enabled: boolean): void => {
         store().setConnectionStatus('error', err instanceof Error ? err.message : String(err))
       })
 
+    // Detect whether the main process is in real Ruflo mode so the UI
+    // can show "LIVE" vs "MOCK MODE" before the first launch.
+    bridge
+      .checkRuflo()
+      .then((available) => {
+        if (cancelled) return
+        // Real mode is active when both RUFLO_REAL_MODE=1 AND ruflo is installed.
+        // The checkRuflo result tells us if ruflo was found; the env var is
+        // already baked into the orchestrator's realMode flag. If ruflo is
+        // found, we optimistically set mockMode to false (the launch result
+        // will confirm or flip it back).
+        if (available) store().setMockMode(false)
+      })
+      .catch(() => {
+        // Non-fatal — leave as mock mode.
+      })
+
     // Pull the persisted project list so the Workspace panel's Recent
     // dropdown is populated before the user interacts with it.
     bridge

--- a/packages/studio-ui/src/pages/DashboardPage.tsx
+++ b/packages/studio-ui/src/pages/DashboardPage.tsx
@@ -21,14 +21,14 @@ const DashboardPage = () => {
   const showCanvas = displayMode !== 'desktop'
 
   return (
-    <main className="flex flex-1 flex-col gap-4 overflow-hidden p-6">
+    <main className="flex flex-1 flex-col gap-4 overflow-y-auto p-6">
       <SwarmOverview />
       <WorkspacePanel />
       <ChatLauncher />
 
       <div
         className={[
-          'grid flex-1 grid-cols-1 gap-4 overflow-hidden transition',
+          'grid min-h-[420px] flex-1 grid-cols-1 gap-4 transition',
           selectedAgentId
             ? 'lg:grid-cols-[minmax(0,3fr)_minmax(0,1.4fr)_minmax(0,1.2fr)]'
             : 'lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]',

--- a/scripts/dev-electron.sh
+++ b/scripts/dev-electron.sh
@@ -10,6 +10,9 @@ cd "$(dirname "$0")/.."
 
 export STUDIO_URL="${STUDIO_URL:-http://localhost:5173}"
 export OVERLAY_URL="${OVERLAY_URL:-http://localhost:5174}"
+# Make sure RUFLO_REAL_MODE is exported so electron-vite → electron → main.ts
+# all see it even if the user set it as a prefix (e.g. RUFLO_REAL_MODE=1 npm run ...).
+export RUFLO_REAL_MODE="${RUFLO_REAL_MODE:-0}"
 
 # CRITICAL: ELECTRON_RUN_AS_NODE=1 in the user's shell environment makes the
 # electron binary behave as plain Node.js, which causes `require('electron')`


### PR DESCRIPTION
## Fixes

### 1. Dashboard not scrollable
The \`<main>\` element used \`overflow-hidden\` which clipped everything below the fold. Changed to \`overflow-y-auto\` + added \`min-h-[420px]\` to the bottom grid so the event log is always reachable by scrolling.

### 2. "MOCK MODE" label doesn't reflect actual mode
\`store.mockMode\` was hardcoded \`true\` and never updated. Now:
- On mount, \`useStudioTransport\` calls \`bridge.checkRuflo()\` and flips \`mockMode\` to \`false\` when Ruflo is available
- After each launch, \`ChatLauncher\` reads \`LaunchResult.mode\` and updates the flag
- Label shows "mock mode" (grey) or "● ruflo live" (cyan) based on actual state

### 3. RUFLO_REAL_MODE not reaching Electron
\`dev-electron.sh\` now explicitly \`export RUFLO_REAL_MODE\` so it propagates through npm → concurrently → electron-vite → Electron main process reliably.

## Test plan
- [ ] Dashboard scrolls to show event log on small viewports
- [ ] \`RUFLO_REAL_MODE=1 npm run dev:electron\` shows "● ruflo live" in the launcher header
- [ ] Default \`npm run dev:electron\` shows "mock mode"

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)