### PR TITLE
perf: keep Pixi scene alive across page switches

### DIFF
--- a/packages/canvas-core/src/sprite-loader.ts
+++ b/packages/canvas-core/src/sprite-loader.ts
@@ -77,15 +77,35 @@ export interface OfficeAssets {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Module-level cache keyed by basePath. Pixi's Assets.load already caches
+ * textures, but fetch()ing the manifest + awaiting the per-variant loads
+ * adds ~100 ms on every re-mount — unacceptable when the user tabs back
+ * to the Office page. Caching the resolved bundle here makes subsequent
+ * mounts synchronous (microtask-fast).
+ */
+const assetsCache = new Map<string, Promise<OfficeAssets | null>>()
+
+/**
  * Load every sprite described by the manifest at `<basePath>/sprite-manifest.json`.
  *
  * Returns `null` if the manifest can't be fetched or any required
  * character variant texture is missing. Callers should treat `null` as
  * "sprites unavailable, fall back to programmatic rendering".
  */
-export const loadOfficeAssets = async (basePath: string): Promise<OfficeAssets | null> => {
+export const loadOfficeAssets = (basePath: string): Promise<OfficeAssets | null> => {
   const trimmedBase = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath
+  const cached = assetsCache.get(trimmedBase)
+  if (cached) return cached
+  const promise = doLoadOfficeAssets(trimmedBase)
+  assetsCache.set(trimmedBase, promise)
+  // If loading fails, don't cache the failure — let the next attempt retry.
+  void promise.then((result) => {
+    if (result === null) assetsCache.delete(trimmedBase)
+  })
+  return promise
+}
 
+const doLoadOfficeAssets = async (trimmedBase: string): Promise<OfficeAssets | null> => {
   // 1. Fetch the manifest.
   let manifest: SpriteManifest
   try {

--- a/packages/studio-ui/src/canvas/IsometricOffice.ts
+++ b/packages/studio-ui/src/canvas/IsometricOffice.ts
@@ -95,6 +95,7 @@ export class IsometricOffice {
   private app: Application | null = null
   private host: HTMLDivElement | null = null
   private spriteAssets: OfficeAssets | null = null
+  private resizeObserver: ResizeObserver | null = null
 
   private readonly world = new Container()
   private readonly monitorLayer = new Container()
@@ -133,8 +134,23 @@ export class IsometricOffice {
 
   // ── lifecycle ──────────────────────────────────────────────────────────────
 
+  /**
+   * Attach the scene's canvas to the given host div.
+   *
+   * First call: boots the Pixi Application, loads sprite assets, and
+   * installs the tick/resize plumbing.
+   * Subsequent calls: the scene is already built — just reparent the
+   * existing canvas to the new host and resize to fit. This is what
+   * makes page-to-page tab switches cheap (no Pixi teardown, no asset
+   * reload, no background re-bake).
+   */
   async attach(host: HTMLDivElement): Promise<void> {
-    if (this.app) return
+    // Already built? Just move the canvas element to the new host.
+    if (this.app) {
+      this.reparentTo(host)
+      return
+    }
+
     this.host = host
     const rect = host.getBoundingClientRect()
 
@@ -187,23 +203,53 @@ export class IsometricOffice {
       if (e.target === app.stage) this.opts.onDeselect?.()
     })
 
-    // Resize handler.
-    const ro = new ResizeObserver(() => {
+    // Resize handler. Kept on the instance so it can re-observe the
+    // new host after suspend/reparent without leaking observers.
+    this.resizeObserver = new ResizeObserver(() => {
       if (!this.app || !this.host) return
       const r = this.host.getBoundingClientRect()
       this.app.renderer.resize(Math.max(320, r.width), Math.max(240, r.height))
       this.fitWorld(r.width, r.height)
     })
-    ro.observe(host)
-    this.cleanup.push(() => ro.disconnect())
+    this.resizeObserver.observe(host)
 
     // Tick loop — as lean as possible.
     app.ticker.add((delta) => this.tick(delta * (1000 / 60)))
   }
 
-  detach(): void {
+  /**
+   * Detach the canvas from the current host without destroying the
+   * Pixi Application. The scene's agents, textures, and ticker stay
+   * alive so a subsequent `attach()` is microtask-fast.
+   *
+   * Used when the React component unmounts on a page switch.
+   */
+  suspend(): void {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect()
+      this.resizeObserver = null
+    }
+    if (this.app && this.host) {
+      const canvas = this.app.view as HTMLCanvasElement
+      if (canvas.parentNode === this.host) this.host.removeChild(canvas)
+    }
+    // Pause the ticker while detached — no point rendering into a
+    // canvas that isn't in the DOM.
+    if (this.app) this.app.ticker.stop()
+    this.host = null
+  }
+
+  /**
+   * Fully destroy the scene — Pixi Application, agents, bubbles, etc.
+   * Only used when the whole Studio window is closing.
+   */
+  destroy(): void {
     for (const fn of this.cleanup) fn()
     this.cleanup = []
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect()
+      this.resizeObserver = null
+    }
     for (const m of this.agents.values()) m.character.destroy({ children: true })
     this.agents.clear()
     for (const b of this.bubbles) b.bubble.destroy({ children: true })
@@ -216,6 +262,39 @@ export class IsometricOffice {
       while (this.host.firstChild) this.host.removeChild(this.host.firstChild)
       this.host = null
     }
+  }
+
+  /** Legacy alias — React cleanup used to destroy the scene; now just suspend. */
+  detach(): void {
+    this.suspend()
+  }
+
+  private reparentTo(host: HTMLDivElement): void {
+    if (!this.app) return
+    const canvas = this.app.view as HTMLCanvasElement
+    if (canvas.parentNode && canvas.parentNode !== host) {
+      canvas.parentNode.removeChild(canvas)
+    }
+    if (canvas.parentNode !== host) host.appendChild(canvas)
+    this.host = host
+
+    // Resume the ticker and re-observe the new host.
+    if (!this.app.ticker.started) this.app.ticker.start()
+    if (!this.resizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => {
+        if (!this.app || !this.host) return
+        const r = this.host.getBoundingClientRect()
+        this.app.renderer.resize(Math.max(320, r.width), Math.max(240, r.height))
+        this.fitWorld(r.width, r.height)
+      })
+    }
+    this.resizeObserver.observe(host)
+
+    // Resize once synchronously so the canvas fills the new host's
+    // current size before the observer's first callback.
+    const r = host.getBoundingClientRect()
+    this.app.renderer.resize(Math.max(320, r.width), Math.max(240, r.height))
+    this.fitWorld(r.width, r.height)
   }
 
   // ── public API ─────────────────────────────────────────────────────────────

--- a/packages/studio-ui/src/components/OfficePanel.tsx
+++ b/packages/studio-ui/src/components/OfficePanel.tsx
@@ -4,6 +4,23 @@ import { IsometricOffice } from '../canvas/IsometricOffice'
 import { selectAgents, useStudioStore } from '../store/studioStore'
 
 /**
+ * Module-level singleton. Keeps the Pixi scene alive across Office ↔
+ * Dashboard page switches so the React component can just reparent
+ * the canvas instead of tearing down the whole Application and
+ * reloading sprite assets on every tab toggle. The previous lifecycle
+ * (create/destroy on every mount) was the dominant cost of a 4-6s
+ * tab switch.
+ */
+let sharedScene: IsometricOffice | null = null
+
+const ensureScene = (onSelectAgent: (id: string) => void, onDeselect: () => void): IsometricOffice => {
+  if (!sharedScene) {
+    sharedScene = new IsometricOffice({ onSelectAgent, onDeselect })
+  }
+  return sharedScene
+}
+
+/**
  * React wrapper around the Pixi.js IsometricOffice scene.
  *
  * Responsibilities:
@@ -34,15 +51,17 @@ const OfficePanel = ({ variant = 'panel' }: OfficePanelProps) => {
   const selectAgent = useStudioStore((s) => s.selectAgent)
   const selectedAgentId = useStudioStore((s) => s.selectedAgentId)
 
-  // Mount / unmount the scene.
+  // Mount / unmount the scene. The scene itself is a module-level
+  // singleton; mount = attach canvas to the new host, unmount = suspend
+  // (keeps the Pixi app alive for the next mount).
   useEffect(() => {
     const host = hostRef.current
     if (!host) return
 
-    const scene = new IsometricOffice({
-      onSelectAgent: (id) => selectAgent(id),
-      onDeselect: () => selectAgent(null),
-    })
+    const scene = ensureScene(
+      (id) => selectAgent(id),
+      () => selectAgent(null),
+    )
     sceneRef.current = scene
     void scene.attach(host).catch((err: unknown) => {
       // eslint-disable-next-line no-console
@@ -55,7 +74,7 @@ const OfficePanel = ({ variant = 'panel' }: OfficePanelProps) => {
 
     return () => {
       sceneRef.current = null
-      scene.detach()
+      scene.suspend()
     }
     // Intentionally run only once — the store subscriptions below keep
     // the scene in sync without re-mounting it.

--- a/packages/studio-ui/src/store/studioStore.ts
+++ b/packages/studio-ui/src/store/studioStore.ts
@@ -846,7 +846,37 @@ const updateChatHistoryStatusForTask = (
 
 // ── Selector helpers ─────────────────────────────────────────────────────────
 
-export const selectAgents = (s: StudioState): AgentInfo[] => Array.from(s.agents.values())
-export const selectTasks = (s: StudioState): TaskInfo[] => Array.from(s.tasks.values())
+/**
+ * Cached array derivations keyed by the source Map reference. Previously
+ * `selectAgents` called `Array.from(map.values())` directly inside a
+ * Zustand selector, which returned a NEW array reference on every store
+ * update. Because Zustand subscribers re-run the selector on every
+ * `set()`, any component using `selectAgents` would re-render for every
+ * event — even unrelated ones like log pushes — and a sluggish tab
+ * switch was the visible symptom.
+ *
+ * Key by Map reference: the store only allocates a new Map when the
+ * agent/task collection actually changes (via `cloneAgentMap` /
+ * `cloneTaskMap`), so the cache invalidates exactly when it should.
+ */
+const agentsArrayCache = new WeakMap<Map<string, AgentInfo>, AgentInfo[]>()
+const tasksArrayCache = new WeakMap<Map<string, TaskInfo>, TaskInfo[]>()
+
+export const selectAgents = (s: StudioState): AgentInfo[] => {
+  const cached = agentsArrayCache.get(s.agents)
+  if (cached) return cached
+  const arr = Array.from(s.agents.values())
+  agentsArrayCache.set(s.agents, arr)
+  return arr
+}
+
+export const selectTasks = (s: StudioState): TaskInfo[] => {
+  const cached = tasksArrayCache.get(s.tasks)
+  if (cached) return cached
+  const arr = Array.from(s.tasks.values())
+  tasksArrayCache.set(s.tasks, arr)
+  return arr
+}
+
 export const selectSelectedAgent = (s: StudioState): AgentInfo | null =>
   s.selectedAgentId ? s.agents.get(s.selectedAgentId) ?? null : null


### PR DESCRIPTION
Closes #35.

## Summary
- `IsometricOffice` is now a module-level singleton; `suspend()` keeps the app alive on React unmount, and `attach()` reparents the existing canvas on the next mount.
- `loadOfficeAssets` memoized at module level so the second mount doesn't re-fetch the manifest.
- `selectAgents` / `selectTasks` cached by source-Map reference so unrelated store events don't re-render subscribers.

## Test plan
- [ ] Toggle between Studio and Dashboard several times — switch should feel instant.
- [ ] Agents, speech bubbles, and desk monitors still render correctly after switching.
- [ ] No console errors on switch (canvas reparent works).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)