### PR TITLE
fix: render Pixi Text at DPR so labels are crisp

### DIFF
--- a/packages/canvas-core/src/character.ts
+++ b/packages/canvas-core/src/character.ts
@@ -349,6 +349,10 @@ export class AgentCharacter extends Container {
     })
     this.nameLabel.anchor.set(0.5, 0)
     this.nameLabel.y = 14
+    // Render glyphs at DPR so name labels stay sharp on Retina even
+    // though the Application runs at resolution 1 for perf.
+    this.nameLabel.resolution =
+      typeof window !== 'undefined' ? Math.max(2, window.devicePixelRatio || 2) : 2
 
     // Dark pill background behind the name label for readability on any
     // background (office floor, desktop wallpaper, etc.).
@@ -374,6 +378,8 @@ export class AgentCharacter extends Container {
     this.exclaim.anchor.set(0.5, 1)
     this.exclaim.y = -(CHAR_HEIGHT - 4)
     this.exclaim.alpha = 0
+    this.exclaim.resolution =
+      typeof window !== 'undefined' ? Math.max(2, window.devicePixelRatio || 2) : 2
     this.addChild(this.exclaim)
 
     this.recoveryCheck = new Text('✓', {
@@ -389,6 +395,8 @@ export class AgentCharacter extends Container {
     this.recoveryCheck.anchor.set(0.5, 1)
     this.recoveryCheck.y = -(CHAR_HEIGHT - 4)
     this.recoveryCheck.alpha = 0
+    this.recoveryCheck.resolution =
+      typeof window !== 'undefined' ? Math.max(2, window.devicePixelRatio || 2) : 2
     this.addChild(this.recoveryCheck)
 
     this.drawStatic()

--- a/packages/canvas-core/src/speech-bubble.ts
+++ b/packages/canvas-core/src/speech-bubble.ts
@@ -53,6 +53,11 @@ export class SpeechBubble extends Container {
       align: 'left',
     })
     text.anchor.set(0.5, 0.5)
+    // The office scene runs the Pixi Application at resolution 1 for
+    // perf, which leaves Text rasterized at 1x and visibly blurry on
+    // Retina. Bump the Text's own resolution to DPR so each glyph
+    // texture is rendered at the display's native pixel density.
+    text.resolution = typeof window !== 'undefined' ? Math.max(2, window.devicePixelRatio || 2) : 2
 
     const bgWidth = Math.min(240, text.width + PADDING * 2 + 8)
     const bgHeight = text.height + PADDING * 2


### PR DESCRIPTION
Closes #36.

## Summary
- Bump `resolution` on speech bubble text + agent name label (plus `!` / `✓` status glyphs) to `devicePixelRatio`.
- Application-wide `resolution: 1` stays put (keeps the perf win from #33) — only the Text textures go up.

## Test plan
- [ ] Trigger a message in the office view, confirm the bubble text is sharp on Retina.
- [ ] Check agent name labels under the characters are sharp.
- [ ] No regression in perf (text nodes are small, bumping their texture resolution is negligible).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)