### PR TITLE
fix(store): default displayMode to 'studio'

### DIFF
--- a/packages/studio-ui/src/store/studioStore.ts
+++ b/packages/studio-ui/src/store/studioStore.ts
@@ -272,7 +272,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
 
   // studio-local UI state
   currentPage: 'office',
-  displayMode: 'both',
+  displayMode: 'studio',
   selectedAgentId: null,
   workspace: null,
   chatHistory: [],


### PR DESCRIPTION
Closes #41.

## Summary
- Boot with Studio-only visible; overlay is now opt-in from the toggle.

## Test plan
- [ ] Fresh app launch shows only the Studio window; desktop overlay is hidden.
- [ ] Toggling to Both / Desktop still works.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)