### PR TITLE
feat(electron): supervise event-bridge from main process

### DIFF
--- a/packages/electron-shell/src/bridge-process.ts
+++ b/packages/electron-shell/src/bridge-process.ts
@@ -1,0 +1,134 @@
+/**
+ * Event-bridge process supervisor.
+ *
+ * Packaged builds and bare `npm run dev -w @agent-studio/electron-shell`
+ * runs have no one to start the bridge. This module spawns it as a
+ * child of Electron main, prefixes its stdout/stderr into the main log,
+ * and kills it on quit. Dev flows that already run the bridge under
+ * `concurrently` can opt out with `RUFLO_EXTERNAL_BRIDGE=1`.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import { createConnection } from 'node:net'
+import path from 'node:path'
+
+import { createLogger } from '@agent-studio/shared'
+
+const log = createLogger('electron-shell:bridge-process')
+
+/** Time to wait for the bridge TCP port to accept a connection, in ms. */
+const READY_TIMEOUT_MS = 10_000
+const READY_PROBE_INTERVAL_MS = 200
+
+export interface BridgeProcessOptions {
+  host: string
+  port: number
+  /** Absolute path to the agent-studio repo root (one up from the app dir in dev). */
+  repoRoot: string
+}
+
+export interface BridgeProcessHandle {
+  /** Wait for the bridge to accept TCP connections; throws on timeout. */
+  waitReady(): Promise<void>
+  /** Kill the child process. Safe to call multiple times. */
+  stop(): Promise<void>
+}
+
+const probePort = (host: string, port: number, timeoutMs: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const socket = createConnection({ host, port, timeout: timeoutMs })
+    const done = (ok: boolean): void => {
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(ok)
+    }
+    socket.once('connect', () => done(true))
+    socket.once('error', () => done(false))
+    socket.once('timeout', () => done(false))
+  })
+
+const waitForPort = async (host: string, port: number): Promise<void> => {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    if (await probePort(host, port, READY_PROBE_INTERVAL_MS)) return
+    await new Promise((r) => setTimeout(r, READY_PROBE_INTERVAL_MS))
+  }
+  throw new Error(`bridge did not accept connections on ${host}:${port} within ${READY_TIMEOUT_MS}ms`)
+}
+
+const forwardStream = (stream: NodeJS.ReadableStream, level: 'info' | 'error'): void => {
+  let buffer = ''
+  stream.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString('utf8')
+    let idx: number
+    while ((idx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, idx).trimEnd()
+      buffer = buffer.slice(idx + 1)
+      if (line.length === 0) continue
+      if (level === 'error') log.error('[bridge] ' + line)
+      else log.info('[bridge] ' + line)
+    }
+  })
+}
+
+/**
+ * Start the event-bridge as a child process. In dev, uses tsx to run
+ * the TypeScript entry directly; the path is resolved relative to
+ * `repoRoot`. If a different invocation is needed (e.g. a packaged
+ * build with a compiled bundle) the caller should opt out via
+ * RUFLO_EXTERNAL_BRIDGE=1 and supervise the bridge themselves.
+ */
+export const startBridgeProcess = (opts: BridgeProcessOptions): BridgeProcessHandle => {
+  const entry = path.join(opts.repoRoot, 'packages/event-bridge/src/server.ts')
+  log.info('spawning event-bridge', { entry, host: opts.host, port: opts.port })
+
+  const child: ChildProcess = spawn('npx', ['--yes', 'tsx', entry], {
+    cwd: opts.repoRoot,
+    env: {
+      ...process.env,
+      BRIDGE_HOST: opts.host,
+      BRIDGE_PORT: String(opts.port),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (child.stdout) forwardStream(child.stdout, 'info')
+  if (child.stderr) forwardStream(child.stderr, 'error')
+
+  child.on('exit', (code, signal) => {
+    log.info('event-bridge exited', { code, signal })
+  })
+  child.on('error', (err) => {
+    log.error('event-bridge spawn error', { error: err instanceof Error ? err.message : String(err) })
+  })
+
+  let stopped = false
+  const stop = async (): Promise<void> => {
+    if (stopped) return
+    stopped = true
+    if (child.exitCode !== null || child.signalCode !== null) return
+    child.kill('SIGTERM')
+    // Give it a moment, then SIGKILL if it hasn't gone.
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          try {
+            child.kill('SIGKILL')
+          } catch {
+            // already dead
+          }
+        }
+        resolve()
+      }, 2000)
+      child.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+
+  return {
+    waitReady: () => waitForPort(opts.host, opts.port),
+    stop,
+  }
+}

--- a/packages/electron-shell/src/main.ts
+++ b/packages/electron-shell/src/main.ts
@@ -17,7 +17,10 @@ import { BrowserWindow, app } from 'electron'
 
 import { createLogger } from '@agent-studio/shared'
 
+import { DEFAULT_BRIDGE_HOST, DEFAULT_BRIDGE_PORT } from '@agent-studio/shared'
+
 import { BridgeClient } from './bridge-client.js'
+import { type BridgeProcessHandle, startBridgeProcess } from './bridge-process.js'
 import { wireIpcBridge } from './ipc-bridge.js'
 import { LaunchOrchestrator } from './launch-orchestrator.js'
 import { createOverlayWindow } from './overlay-window.js'
@@ -61,6 +64,7 @@ interface RuntimeHandles {
   overlayWindow: BrowserWindow | null
   tray: Electron.Tray | null
   bridgeClient: BridgeClient | null
+  bridgeProcess: BridgeProcessHandle | null
   launchOrchestrator: LaunchOrchestrator | null
   teardownIpc: (() => void) | null
 }
@@ -70,9 +74,14 @@ const runtime: RuntimeHandles = {
   overlayWindow: null,
   tray: null,
   bridgeClient: null,
+  bridgeProcess: null,
   launchOrchestrator: null,
   teardownIpc: null,
 }
+
+const EXTERNAL_BRIDGE = process.env.RUFLO_EXTERNAL_BRIDGE === '1'
+const BRIDGE_HOST = process.env.BRIDGE_HOST ?? DEFAULT_BRIDGE_HOST
+const BRIDGE_PORT = Number(process.env.BRIDGE_PORT ?? DEFAULT_BRIDGE_PORT)
 
 const buildStudioWindow = (): BrowserWindow => {
   const window = createStudioWindow({
@@ -112,13 +121,46 @@ const ensureWindows = (): void => {
   }
 }
 
+const resolveRepoRoot = (): string => {
+  // In dev, electron runs from packages/electron-shell — the repo root is
+  // three levels up from the compiled out/main/ directory.
+  // In a packaged app, main.js lives inside app.asar; the bridge cannot
+  // run from source in that case and the operator must supply their own
+  // via RUFLO_EXTERNAL_BRIDGE=1.
+  return path.resolve(__dirname, '../../../..')
+}
+
 const startup = async (): Promise<void> => {
   log.info('starting agent studio shell', {
     isDev,
     studioUrl: STUDIO_URL,
     overlayUrl: OVERLAY_URL,
     preload: PRELOAD_PATH,
+    externalBridge: EXTERNAL_BRIDGE,
   })
+
+  if (!EXTERNAL_BRIDGE) {
+    if (app.isPackaged) {
+      log.warn(
+        'running packaged build without RUFLO_EXTERNAL_BRIDGE=1 — ' +
+          'auto-supervising the bridge via tsx is not supported in packaged builds, ' +
+          'the UI will stay in "bridge offline" until a bridge is reachable',
+      )
+    } else {
+      runtime.bridgeProcess = startBridgeProcess({
+        host: BRIDGE_HOST,
+        port: BRIDGE_PORT,
+        repoRoot: resolveRepoRoot(),
+      })
+      try {
+        await runtime.bridgeProcess.waitReady()
+      } catch (err) {
+        log.error('bridge failed to become ready', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
 
   runtime.bridgeClient = new BridgeClient()
   runtime.bridgeClient.start()
@@ -180,7 +222,10 @@ app.on('window-all-closed', () => {
   }
 })
 
-app.on('before-quit', () => {
+let beforeQuitRan = false
+app.on('before-quit', (event) => {
+  if (beforeQuitRan) return
+  beforeQuitRan = true
   log.info('app quitting, tearing down')
   // Stop any running swarm child process before tearing down IPC.
   runtime.launchOrchestrator?.stop()
@@ -189,5 +234,13 @@ app.on('before-quit', () => {
   if (runtime.tray) {
     runtime.tray.destroy()
     runtime.tray = null
+  }
+  // Kill the bridge child asynchronously but let Electron wait on us.
+  if (runtime.bridgeProcess) {
+    event.preventDefault()
+    void runtime.bridgeProcess.stop().finally(() => {
+      runtime.bridgeProcess = null
+      app.quit()
+    })
   }
 })

--- a/packages/event-bridge/src/server.ts
+++ b/packages/event-bridge/src/server.ts
@@ -290,5 +290,11 @@ const isEntrypoint = (() => {
 })();
 
 if (isEntrypoint) {
-  startBridge();
+  const envHost = process.env.BRIDGE_HOST;
+  const envPortRaw = process.env.BRIDGE_PORT;
+  const envPort = envPortRaw ? Number(envPortRaw) : undefined;
+  startBridge({
+    ...(envHost ? { host: envHost } : {}),
+    ...(envPort && Number.isFinite(envPort) ? { port: envPort } : {}),
+  });
 }

--- a/scripts/dev-electron.sh
+++ b/scripts/dev-electron.sh
@@ -21,6 +21,10 @@ export RUFLO_REAL_MODE="${RUFLO_REAL_MODE:-0}"
 # matter what the developer's shell is configured to.
 unset ELECTRON_RUN_AS_NODE
 
+# This dev script already supervises the bridge under `concurrently`, so
+# tell Electron main to skip its own supervision path and just connect.
+export RUFLO_EXTERNAL_BRIDGE=1
+
 if [ "${RUFLO_REAL_MODE:-0}" = "1" ]; then
   echo "[dev-electron] RUFLO_REAL_MODE=1 — skipping mock generator, waiting for real swarms"
   exec npx --yes concurrently \


### PR DESCRIPTION
Closes #44.

## Summary
- New `bridge-process.ts` spawns the event-bridge as a child of Electron main (via `tsx` against the repo source), forwards stdout/stderr with a `[bridge]` prefix, probes the TCP port for readiness, and kills it on quit.
- `RUFLO_EXTERNAL_BRIDGE=1` opt-out for dev scripts that already supervise the bridge under `concurrently`. `scripts/dev-electron.sh` sets this flag.
- Event-bridge server now reads `BRIDGE_HOST` / `BRIDGE_PORT` env vars.

## Test plan
- [ ] `npm run dev:electron` still works (bridge supervised by concurrently, main connects via the escape hatch).
- [ ] Running electron directly without concurrently: main spawns the bridge, logs a `[bridge] ... listening` line, UI connects.
- [ ] App quit cleanly kills the bridge child (no orphan on port 6747).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)