### PR TITLE
feat(bridge): tag producer origin to prevent mock/real collisions

### DIFF
--- a/packages/electron-shell/src/bridge-client.ts
+++ b/packages/electron-shell/src/bridge-client.ts
@@ -16,6 +16,7 @@ import WebSocket from 'ws'
 import {
   type BridgeConnectionStatus,
   type EventEnvelope,
+  type ProducerOrigin,
   type ProjectSession,
   type StudioEvent,
   type WireMessage,
@@ -43,6 +44,7 @@ type BridgeClientEvents = {
   status: [BridgeConnectionStatus]
   snapshot: [WorldSnapshot]
   projects: [ProjectSession[]]
+  producer: [ProducerOrigin | null]
 }
 
 /**
@@ -63,6 +65,8 @@ export class BridgeClient extends EventEmitter<BridgeClientEvents> {
   private reconnectTimer: NodeJS.Timeout | null = null
   private heartbeatTimer: NodeJS.Timeout | null = null
   private closed = false
+  /** True once we've sent a hello as an orchestrator producer. */
+  private announcedProducer = false
   /** Callbacks waiting for the next projects:list-response. */
   private pendingProjectRequests: Array<(projects: ProjectSession[]) => void> = []
 
@@ -115,6 +119,13 @@ export class BridgeClient extends EventEmitter<BridgeClientEvents> {
    * report failure to the user.
    */
   sendEvent(event: StudioEvent, source: string = SOURCE_PLUGIN): void {
+    // Lazy hello — on first event, announce ourselves to the bridge
+    // as an orchestrator-origin producer. See connect()'s open handler
+    // for the reconnect path.
+    if (!this.announcedProducer) {
+      this.announcedProducer = true
+      this.send({ kind: 'hello', origin: 'orchestrator', label: 'electron-shell' })
+    }
     const envelope: EventEnvelope = { kind: 'event', source, event }
     this.send(envelope)
   }
@@ -185,7 +196,16 @@ export class BridgeClient extends EventEmitter<BridgeClientEvents> {
       this.setStatus('connected')
       this.startHeartbeat()
       // Ask for the current snapshot so newly opened windows have data.
+      // We intentionally DO NOT announce ourselves as a producer up
+      // front — that only happens on the first sendEvent() call so an
+      // idle Electron instance doesn't suppress a concurrent
+      // mock-events.ts producer.
       this.send({ kind: 'replay:request' })
+      // If we've previously produced events in this session, re-announce
+      // after a reconnect so the bridge knows our origin again.
+      if (this.announcedProducer) {
+        this.send({ kind: 'hello', origin: 'orchestrator', label: 'electron-shell' })
+      }
     })
 
     socket.on('message', (data) => {
@@ -276,6 +296,10 @@ export class BridgeClient extends EventEmitter<BridgeClientEvents> {
         for (const waiter of waiters) waiter([...message.projects])
         return
       }
+      case 'producer:active':
+        this.emit('producer', message.origin)
+        return
+      case 'hello':
       case 'pong':
       case 'ping':
       case 'replay:request':

--- a/packages/electron-shell/src/ipc-bridge.ts
+++ b/packages/electron-shell/src/ipc-bridge.ts
@@ -96,6 +96,7 @@ export const wireIpcBridge = (options: WireOptions): (() => void) => {
       tasks: [],
       messages: [],
       swarm: null,
+      activeProducer: null,
       snapshotAt: Date.now(),
     }
   })

--- a/packages/event-bridge/src/server.ts
+++ b/packages/event-bridge/src/server.ts
@@ -18,6 +18,8 @@ import { ZodError } from 'zod';
 
 import {
   type EventEnvelope,
+  type ProducerActiveMessage,
+  type ProducerOrigin,
   type ReplayResponse,
   type WireMessage,
   DEFAULT_BRIDGE_HOST,
@@ -38,9 +40,20 @@ interface ClientMeta {
   id: string;
   /** Producer = sends events; consumer = receives broadcasts. A client may be both. */
   role: 'producer' | 'consumer' | 'unknown';
+  /** For producers: which origin they announced via `hello` (or inferred). */
+  origin: ProducerOrigin | null;
+  /** Free-form label for logs. */
+  label: string | null;
   connectedAt: number;
   isAlive: boolean;
 }
+
+/** Priority among simultaneously-connected producers — high number wins. */
+const ORIGIN_PRIORITY: Record<ProducerOrigin, number> = {
+  ruflo: 3,
+  orchestrator: 2,
+  mock: 1,
+};
 
 interface BridgeOptions {
   host?: string;
@@ -81,6 +94,8 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
     const meta: ClientMeta = {
       id: `c${nextClientId++}`,
       role: 'unknown',
+      origin: null,
+      label: null,
       connectedAt: Date.now(),
       isAlive: true,
     };
@@ -108,7 +123,12 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
 
     socket.on('close', () => {
       clients.delete(socket);
-      log.info('client disconnected', { clientId: meta.id, total: clients.size });
+      log.info('client disconnected', {
+        clientId: meta.id,
+        origin: meta.origin,
+        total: clients.size,
+      });
+      if (meta.origin) recomputeActiveProducer();
     });
 
     socket.on('error', (err) => {
@@ -161,8 +181,39 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
     }
 
     switch (message.kind) {
+      case 'hello': {
+        meta.origin = message.origin;
+        meta.label = message.label ?? null;
+        // Only upgrade role if the socket hadn't already announced
+        // itself as a consumer (via replay:request). A single socket
+        // can be both — e.g. the electron-shell bridge-client consumes
+        // broadcasts AND produces orchestrator-originated events.
+        if (meta.role === 'unknown') meta.role = 'producer';
+        log.info('producer announced', {
+          clientId: meta.id,
+          origin: meta.origin,
+          label: meta.label,
+          role: meta.role,
+        });
+        recomputeActiveProducer();
+        return;
+      }
       case 'event': {
         if (meta.role === 'unknown') meta.role = 'producer';
+        // Producers that never sent `hello` are assumed to be lowest-
+        // priority so they don't silently override a live ruflo stream.
+        if (meta.origin === null) meta.origin = 'mock';
+        // Gate: only the currently active producer's events are applied.
+        const active = stateStore.getActiveProducer();
+        if (active !== null && meta.origin !== active) {
+          log.debug?.('dropping event from non-active producer', {
+            clientId: meta.id,
+            origin: meta.origin,
+            active,
+          });
+          return;
+        }
+        if (active === null) recomputeActiveProducer();
         const applied = stateStore.applyEvent(message.event);
         if (applied) {
           recorder.record(message.event);
@@ -177,6 +228,12 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
           snapshot: stateStore.getFullState(),
         };
         sendJson(socket, response);
+        // Also push the current active producer so the UI doesn't
+        // have to wait for the next transition to know the state.
+        sendJson(socket, {
+          kind: 'producer:active',
+          origin: stateStore.getActiveProducer(),
+        });
         return;
       }
       case 'ping': {
@@ -214,7 +271,8 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
       }
       case 'pong':
       case 'replay:response':
-      case 'projects:list-response': {
+      case 'projects:list-response':
+      case 'producer:active': {
         // No-op — these are bridge → client messages.
         return;
       }
@@ -235,6 +293,42 @@ export const startBridge = (options: BridgeOptions = {}): BridgeHandle => {
         socket.send(payload);
       } catch (err) {
         log.warn('broadcast send failed', { clientId: meta.id, error: String(err) });
+      }
+    }
+  };
+
+  /**
+   * Scan producers and pick the highest-priority origin currently
+   * connected. Updates state and broadcasts to consumers if the active
+   * origin changed.
+   */
+  const recomputeActiveProducer = (): void => {
+    let best: ProducerOrigin | null = null;
+    // Consider any connected client that has announced an origin, even
+    // if it's also serving as a consumer (dual-role sockets are valid).
+    for (const meta of clients.values()) {
+      if (!meta.origin) continue;
+      if (best === null || ORIGIN_PRIORITY[meta.origin] > ORIGIN_PRIORITY[best]) {
+        best = meta.origin;
+      }
+    }
+    const prev = stateStore.getActiveProducer();
+    if (prev === best) return;
+    stateStore.setActiveProducer(best);
+    log.info('active producer changed', { from: prev, to: best });
+    broadcastProducerActive(best);
+  };
+
+  const broadcastProducerActive = (origin: ProducerOrigin | null): void => {
+    const message: ProducerActiveMessage = { kind: 'producer:active', origin };
+    const payload = JSON.stringify(message);
+    for (const [socket, meta] of clients) {
+      if (meta.role === 'producer') continue;
+      if (socket.readyState !== socket.OPEN) continue;
+      try {
+        socket.send(payload);
+      } catch (err) {
+        log.warn('producer:active broadcast failed', { clientId: meta.id, error: String(err) });
       }
     }
   };

--- a/packages/event-bridge/src/state-store.ts
+++ b/packages/event-bridge/src/state-store.ts
@@ -19,6 +19,7 @@ import type { Database as SqliteDatabase, Statement } from 'better-sqlite3';
 import {
   type AgentInfo,
   type AgentMessage,
+  type ProducerOrigin,
   type ProjectSession,
   type StudioEvent,
   type SwarmInfo,
@@ -144,6 +145,16 @@ export class StateStore {
     return applied;
   }
 
+  private activeProducer: ProducerOrigin | null = null;
+
+  setActiveProducer(origin: ProducerOrigin | null): void {
+    this.activeProducer = origin;
+  }
+
+  getActiveProducer(): ProducerOrigin | null {
+    return this.activeProducer;
+  }
+
   /** Snapshot the entire world state — used to bootstrap newly connected UI clients. */
   getFullState(): WorldSnapshot {
     return {
@@ -151,6 +162,7 @@ export class StateStore {
       tasks: Array.from(this.tasks.values()),
       messages: [...this.messages],
       swarm: this.swarm,
+      activeProducer: this.activeProducer,
       snapshotAt: Date.now(),
     };
   }

--- a/packages/ruflo-plugin/src/event-emitter.ts
+++ b/packages/ruflo-plugin/src/event-emitter.ts
@@ -16,6 +16,8 @@ import WebSocket from 'ws';
 
 import {
   type EventEnvelope,
+  type HelloMessage,
+  type ProducerOrigin,
   type StudioEvent,
   DEFAULT_BRIDGE_HOST,
   DEFAULT_BRIDGE_PORT,
@@ -35,6 +37,11 @@ interface EmitterOptions {
   url?: string;
   /** Identifier put into the EventEnvelope.source field. */
   source?: string;
+  /**
+   * Typed producer origin announced to the bridge on connect. Defaults
+   * to 'ruflo' since this emitter lives in the ruflo plugin.
+   */
+  origin?: ProducerOrigin;
   /** Maximum events to buffer while disconnected. Older events are dropped. */
   maxBufferSize?: number;
 }
@@ -43,6 +50,7 @@ interface EmitterOptions {
 export class StudioEventEmitter {
   private readonly url: string;
   private readonly source: string;
+  private readonly origin: ProducerOrigin;
   private readonly maxBufferSize: number;
   private socket: WebSocket | null = null;
   private connecting = false;
@@ -54,6 +62,7 @@ export class StudioEventEmitter {
   constructor(options: EmitterOptions = {}) {
     this.url = options.url ?? defaultBridgeUrl(DEFAULT_BRIDGE_HOST, DEFAULT_BRIDGE_PORT);
     this.source = options.source ?? SOURCE_PLUGIN;
+    this.origin = options.origin ?? 'ruflo';
     this.maxBufferSize = options.maxBufferSize ?? 500;
   }
 
@@ -135,7 +144,19 @@ export class StudioEventEmitter {
     socket.once('open', () => {
       this.connecting = false;
       this.reconnectAttempt = 0;
-      log.info('connected to bridge', { url: this.url });
+      log.info('connected to bridge', { url: this.url, origin: this.origin });
+      // Announce who we are before sending events so the bridge can
+      // route/gate appropriately (ruflo > orchestrator > mock).
+      const hello: HelloMessage = {
+        kind: 'hello',
+        origin: this.origin,
+        label: this.source,
+      };
+      try {
+        socket.send(JSON.stringify(hello));
+      } catch (err) {
+        log.warn('hello send failed', { error: String(err) });
+      }
       this.flushBuffer();
     });
 

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -60,11 +60,14 @@ export const SwarmInfoSchema = z.object({
   startedAt: z.number().int().nonnegative(),
 });
 
+export const ProducerOriginSchema = z.enum(['ruflo', 'orchestrator', 'mock']);
+
 export const WorldSnapshotSchema = z.object({
   agents: z.array(AgentInfoSchema),
   tasks: z.array(TaskInfoSchema),
   messages: z.array(AgentMessageSchema),
   swarm: SwarmInfoSchema.nullable(),
+  activeProducer: ProducerOriginSchema.nullable(),
   snapshotAt: z.number().int().nonnegative(),
 });
 
@@ -219,6 +222,17 @@ export const EventEnvelopeSchema = z.object({
   event: StudioEventSchema,
 });
 
+export const HelloMessageSchema = z.object({
+  kind: z.literal('hello'),
+  origin: ProducerOriginSchema,
+  label: z.string().optional(),
+});
+
+export const ProducerActiveMessageSchema = z.object({
+  kind: z.literal('producer:active'),
+  origin: ProducerOriginSchema.nullable(),
+});
+
 export const ReplayRequestSchema = z.object({
   kind: z.literal('replay:request'),
 });
@@ -254,6 +268,8 @@ export const ProjectSaveRequestSchema = z.object({
 
 export const WireMessageSchema = z.discriminatedUnion('kind', [
   EventEnvelopeSchema,
+  HelloMessageSchema,
+  ProducerActiveMessageSchema,
   ReplayRequestSchema,
   ReplayResponseSchema,
   PingMessageSchema,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -114,6 +114,8 @@ export interface WorldSnapshot {
   tasks: TaskInfo[];
   messages: AgentMessage[];
   swarm: SwarmInfo | null;
+  /** Currently active event producer, null if no producer is connected. */
+  activeProducer: ProducerOrigin | null;
   /** Unix epoch ms when the snapshot was captured. */
   snapshotAt: number;
 }
@@ -293,6 +295,38 @@ export type StudioEventType = StudioEvent['type'];
 // Wire protocol — what actually goes over the WebSocket.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Typed producer origin. Identifies who's pushing events at the bridge
+ * so the UI can render a truthful "live / mock" indicator and the
+ * bridge can resolve collisions when multiple producers are attached.
+ *
+ * Priority (highest wins when more than one is connected):
+ *   ruflo > orchestrator > mock
+ */
+export type ProducerOrigin = 'ruflo' | 'orchestrator' | 'mock';
+
+/**
+ * First message a producer sends after connecting. Announces which
+ * origin it represents. If a producer omits this and starts emitting
+ * events, the bridge assumes origin 'mock' — the weakest priority.
+ */
+export interface HelloMessage {
+  kind: 'hello';
+  origin: ProducerOrigin;
+  /** Free-form label for logs (e.g. '@agent-studio/ruflo-plugin@0.1.0'). */
+  label?: string;
+}
+
+/**
+ * Bridge tells consumers which producer origin is currently "in charge"
+ * so the UI header can show "Live Ruflo" vs "Mock" vs "—". Emitted on
+ * every transition and also on initial connect.
+ */
+export interface ProducerActiveMessage {
+  kind: 'producer:active';
+  origin: ProducerOrigin | null;
+}
+
 /** A producer (plugin/mock) sends an event to the bridge. */
 export interface EventEnvelope {
   kind: 'event';
@@ -346,6 +380,8 @@ export interface ProjectSaveRequest {
 /** Every message that can flow over the WebSocket, in either direction. */
 export type WireMessage =
   | EventEnvelope
+  | HelloMessage
+  | ProducerActiveMessage
   | ReplayRequest
   | ReplayResponse
   | PingMessage

--- a/scripts/mock-events.ts
+++ b/scripts/mock-events.ts
@@ -121,6 +121,15 @@ class MockRunner {
       try {
         this.socket = await openSocket(this.url)
         log.info('connected to bridge', { url: this.url, speed: this.speed })
+        // Announce origin — the bridge uses this to resolve producer
+        // priority if a real ruflo producer is also connected.
+        try {
+          this.socket.send(
+            JSON.stringify({ kind: 'hello', origin: 'mock', label: 'mock-events' }),
+          )
+        } catch (err) {
+          log.warn('hello send failed', { error: String(err) })
+        }
         this.socket.on('close', (code, reason) => {
           log.warn('disconnected from bridge', { code, reason: reason.toString() })
           process.exit(0)


### PR DESCRIPTION
Closes #47. Foundational for #45 and #48.

## Summary
- New wire protocol: \`hello\` (producer → bridge) + \`producer:active\` (bridge → consumers).
- Priority: \`ruflo > orchestrator > mock\`. Lower-priority producers' events are dropped while a higher one is connected.
- \`WorldSnapshot.activeProducer\` carries the current origin for replay.
- Dual-role sockets (consumer + producer on one connection) still work — the electron-shell bridge-client lazily declares orchestrator origin only on first \`sendEvent\`.

## Test plan
- [ ] Run mock alongside Electron: UI shows mock data normally (no ruflo yet → mock wins by default).
- [ ] Start a simulated ruflo producer (origin='ruflo'): mock events get dropped in favor of ruflo.
- [ ] ruflo disconnects → mock events start flowing again.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)