### PR TITLE
feat(ui): header pill shows live producer origin (Ruflo / Orchestrator / Mock / Offline)

### DIFF
--- a/packages/electron-shell/src/ipc-bridge.ts
+++ b/packages/electron-shell/src/ipc-bridge.ts
@@ -14,6 +14,7 @@ import {
   type BridgeConnectionStatus,
   type LaunchParams,
   type LaunchResult,
+  type ProducerOrigin,
   type ProjectSession,
   type StudioEvent,
   type WorkspaceInfo,
@@ -68,6 +69,9 @@ export const wireIpcBridge = (options: WireOptions): (() => void) => {
   const onStatus = (status: BridgeConnectionStatus) => {
     broadcast(IPC_CHANNELS.STUDIO_CONNECTION, status)
   }
+  const onProducer = (origin: ProducerOrigin | null) => {
+    broadcast(IPC_CHANNELS.STUDIO_PRODUCER, origin)
+  }
   const onSnapshot = (snapshot: WorldSnapshot) => {
     // Snapshots aren't pushed continuously — renderers ask for them via
     // STUDIO_GET_STATE. We just keep the latest cached on the bridge client
@@ -81,6 +85,7 @@ export const wireIpcBridge = (options: WireOptions): (() => void) => {
 
   bridgeClient.on('event', onEvent)
   bridgeClient.on('status', onStatus)
+  bridgeClient.on('producer', onProducer)
   bridgeClient.on('snapshot', onSnapshot)
 
   // ── renderer → main (invoke) ───────────────────────────────────────────────
@@ -245,6 +250,7 @@ export const wireIpcBridge = (options: WireOptions): (() => void) => {
   return () => {
     bridgeClient.off('event', onEvent)
     bridgeClient.off('status', onStatus)
+    bridgeClient.off('producer', onProducer)
     bridgeClient.off('snapshot', onSnapshot)
     ipcMain.removeHandler(IPC_CHANNELS.STUDIO_GET_STATE)
     ipcMain.removeHandler(IPC_CHANNELS.WORKSPACE_PICK)

--- a/packages/electron-shell/src/preload.ts
+++ b/packages/electron-shell/src/preload.ts
@@ -16,6 +16,7 @@ import {
   type BridgeConnectionStatus,
   type LaunchParams,
   type LaunchResult,
+  type ProducerOrigin,
   type ProjectSession,
   type RendererRole,
   type StudioBridgeApi,
@@ -60,6 +61,16 @@ const api: StudioBridgeApi = {
     ipcRenderer.on(IPC_CHANNELS.STUDIO_CONNECTION, wrapped)
     return () => {
       ipcRenderer.removeListener(IPC_CHANNELS.STUDIO_CONNECTION, wrapped)
+    }
+  },
+
+  onProducer(handler) {
+    const wrapped = (_event: Electron.IpcRendererEvent, origin: ProducerOrigin | null) => {
+      handler(origin)
+    }
+    ipcRenderer.on(IPC_CHANNELS.STUDIO_PRODUCER, wrapped)
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.STUDIO_PRODUCER, wrapped)
     }
   },
 

--- a/packages/shared/src/electron-api.ts
+++ b/packages/shared/src/electron-api.ts
@@ -13,6 +13,7 @@
 
 import type {
   AgentType,
+  ProducerOrigin,
   ProjectSession,
   StudioEvent,
   WorldSnapshot,
@@ -112,6 +113,14 @@ export interface StudioBridgeApi {
    * subscribe so consumers don't need to poll.
    */
   onConnection(handler: (status: BridgeConnectionStatus) => void): Unsubscribe;
+
+  /**
+   * Subscribe to active producer changes (ruflo / orchestrator / mock /
+   * null). Fires whenever a higher-priority producer connects or a
+   * current one disconnects, and once on subscribe with the last-known
+   * origin so the UI can render status without waiting for a transition.
+   */
+  onProducer(handler: (origin: ProducerOrigin | null) => void): Unsubscribe;
 
   /** Request the current full world snapshot from the main process. */
   requestState(): Promise<WorldSnapshot>;
@@ -219,6 +228,8 @@ export const IPC_CHANNELS = {
   STUDIO_EVENT: 'studio:event',
   /** main → renderer: bridge connection status changed */
   STUDIO_CONNECTION: 'studio:connection',
+  /** main → renderer: active producer origin changed */
+  STUDIO_PRODUCER: 'studio:producer',
   /** main → renderer: focus a specific agent in the studio panel */
   STUDIO_FOCUS_AGENT: 'studio:focus-agent',
   /** renderer → main (invoke): get current world snapshot */

--- a/packages/studio-ui/src/components/AppHeader.tsx
+++ b/packages/studio-ui/src/components/AppHeader.tsx
@@ -1,6 +1,8 @@
+import type { ProducerOrigin } from '@agent-studio/shared'
+
 import DisplayModeToggle from './DisplayModeToggle'
 import PageToggle from './PageToggle'
-import { useStudioStore } from '../store/studioStore'
+import { useStudioStore, type ConnectionStatus } from '../store/studioStore'
 
 /**
  * Shared header rendered by both pages. Owns the product identity, the
@@ -9,8 +11,74 @@ import { useStudioStore } from '../store/studioStore'
  * The header is intentionally slim so the OfficePage can give the
  * isometric canvas as much vertical room as possible.
  */
+
+interface PillSpec {
+  label: string
+  dotClass: string
+  textClass: string
+  title: string
+}
+
+const resolvePill = (
+  status: ConnectionStatus,
+  producer: ProducerOrigin | null,
+): PillSpec => {
+  if (status === 'connecting') {
+    return {
+      label: 'connecting…',
+      dotClass: 'bg-amber-400 animate-pulse',
+      textClass: 'text-amber-300',
+      title: 'Attempting to reach the event bridge',
+    }
+  }
+  if (status !== 'connected') {
+    return {
+      label: 'bridge offline',
+      dotClass: 'bg-rose-500',
+      textClass: 'text-rose-300',
+      title:
+        'Bridge unreachable — the UI is running but no events are flowing. ' +
+        'Check that the event-bridge process is running.',
+    }
+  }
+  if (producer === 'ruflo') {
+    return {
+      label: 'live · ruflo',
+      dotClass: 'bg-accent shadow-glow',
+      textClass: 'text-accent',
+      title: 'Connected to bridge; events coming from a real Ruflo daemon',
+    }
+  }
+  if (producer === 'orchestrator') {
+    return {
+      label: 'live · orchestrator',
+      dotClass: 'bg-sky-400 shadow-glow',
+      textClass: 'text-sky-300',
+      title: 'Connected to bridge; events coming from the launch orchestrator',
+    }
+  }
+  if (producer === 'mock') {
+    return {
+      label: 'mock',
+      dotClass: 'bg-amber-300',
+      textClass: 'text-amber-200',
+      title:
+        'Connected to bridge; events are synthesized by the mock generator. ' +
+        'Start Ruflo with the plugin loaded to switch to a live feed.',
+    }
+  }
+  return {
+    label: 'idle',
+    dotClass: 'bg-slate-500',
+    textClass: 'text-slate-400',
+    title: 'Connected to bridge; no producer is attached yet',
+  }
+}
+
 const AppHeader = () => {
   const connectionStatus = useStudioStore((s) => s.connectionStatus)
+  const activeProducer = useStudioStore((s) => s.activeProducer)
+  const pill = resolvePill(connectionStatus, activeProducer)
 
   return (
     <header className="flex shrink-0 items-center justify-between gap-6 border-b border-ink-800 bg-ink-900/70 px-6 py-3 backdrop-blur">
@@ -31,14 +99,12 @@ const AppHeader = () => {
         <DisplayModeToggle />
       </div>
 
-      <div className="font-mono text-xs text-slate-500">
-        {connectionStatus === 'connected' ? (
-          <span className="text-accent">● bridge connected</span>
-        ) : connectionStatus === 'connecting' ? (
-          <span className="text-amber-300">○ connecting…</span>
-        ) : (
-          <span className="text-rose-400">○ bridge offline</span>
-        )}
+      <div
+        className={`flex items-center gap-2 rounded-full border border-ink-800 bg-ink-900/60 px-3 py-1 font-mono text-xs ${pill.textClass}`}
+        title={pill.title}
+      >
+        <span className={`h-2 w-2 rounded-full ${pill.dotClass}`} />
+        <span>{pill.label}</span>
       </div>
     </header>
   )

--- a/packages/studio-ui/src/hooks/useStudioTransport.ts
+++ b/packages/studio-ui/src/hooks/useStudioTransport.ts
@@ -94,6 +94,9 @@ const useElectronTransport = (enabled: boolean): void => {
     const offConnection = bridge.onConnection((status) => {
       store().setConnectionStatus(status)
     })
+    const offProducer = bridge.onProducer((origin) => {
+      store().setActiveProducer(origin)
+    })
     const offFocus = bridge.onAgentFocused((agentId) => {
       store().selectAgent(agentId)
     })
@@ -102,6 +105,7 @@ const useElectronTransport = (enabled: boolean): void => {
       cancelled = true
       offEvent()
       offConnection()
+      offProducer()
       offFocus()
     }
   }, [enabled])

--- a/packages/studio-ui/src/hooks/useWebSocket.ts
+++ b/packages/studio-ui/src/hooks/useWebSocket.ts
@@ -92,6 +92,9 @@ export const useWebSocket = (options: UseWebSocketOptions = {}): void => {
         case 'replay:response':
           store().hydrateFromSnapshot(message.snapshot)
           return
+        case 'producer:active':
+          store().setActiveProducer(message.origin)
+          return
         case 'pong':
         case 'ping':
         case 'replay:request':

--- a/packages/studio-ui/src/store/studioStore.ts
+++ b/packages/studio-ui/src/store/studioStore.ts
@@ -24,6 +24,7 @@ import type {
   AgentMessage,
   AgentType,
   ChatHistoryRecord,
+  ProducerOrigin,
   ProjectSession,
   StudioEvent,
   SwarmInfo,
@@ -95,6 +96,12 @@ interface StudioState {
   swarm: SwarmInfo | null
   log: LoggedEvent[]
   connectionStatus: ConnectionStatus
+  /**
+   * Which producer the bridge is currently attributing events to
+   * ('ruflo' | 'orchestrator' | 'mock' | null). Source of truth for the
+   * header "Live Ruflo / Mock / Disconnected" pill.
+   */
+  activeProducer: ProducerOrigin | null
   lastError: string | null
   startedAt: number | null
 
@@ -125,6 +132,7 @@ interface StudioState {
 
   // ── actions ──────────────────────────────────────────────────────────────
   setConnectionStatus(status: ConnectionStatus, error?: string | null): void
+  setActiveProducer(origin: ProducerOrigin | null): void
   hydrateFromSnapshot(snapshot: WorldSnapshot): void
   applyEvent(event: StudioEvent): void
   reset(): void
@@ -267,6 +275,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   swarm: null,
   log: [],
   connectionStatus: 'idle',
+  activeProducer: null,
   lastError: null,
   startedAt: null,
 
@@ -295,6 +304,10 @@ export const useStudioStore = create<StudioState>((set, get) => ({
     set({ connectionStatus: status, lastError: error })
   },
 
+  setActiveProducer(origin) {
+    set({ activeProducer: origin })
+  },
+
   hydrateFromSnapshot(snapshot) {
     const agents = new Map<string, AgentInfo>()
     for (const a of snapshot.agents) agents.set(a.id, a)
@@ -305,6 +318,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       tasks,
       messages: snapshot.messages.slice(-MAX_MESSAGE_HISTORY),
       swarm: snapshot.swarm,
+      activeProducer: snapshot.activeProducer,
       startedAt: snapshot.swarm?.startedAt ?? null,
     })
   },


### PR DESCRIPTION
Closes #48.

## Summary
- Header pill now reflects both bridge connection status AND active producer origin (from #47).
- Five states: \`live · ruflo\` / \`live · orchestrator\` / \`mock\` / \`idle\` / \`bridge offline\` / \`connecting…\`, each with an actionable tooltip.
- Adds \`activeProducer\` to the Zustand store; wired through IPC (new \`STUDIO_PRODUCER\` channel + \`onProducer\` preload API) and through the plain-browser WebSocket hook.

## Test plan
- [ ] Start mock-events alongside Electron — pill shows \`mock\`.
- [ ] Stop mock — pill goes to \`idle\`.
- [ ] Kill the bridge — pill goes \`bridge offline\` with retry tooltip.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)